### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "12.x"
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "${{ matrix.node_version }}"
+          cache: npm
       - run: npm ci
       - run: npm test
   test:

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           version: 12
+          cache: npm
       - run: npm ci
       - run: "npm run lint:fix"
       - uses: gr2m/create-or-update-pull-request-action@v1.x


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
